### PR TITLE
Added failsafe font for Museo Sans

### DIFF
--- a/src/forms/TopComponent/Utils/TitleWrapper.tsx
+++ b/src/forms/TopComponent/Utils/TitleWrapper.tsx
@@ -10,8 +10,8 @@ import theme, { BREAKPOINTS } from "@root/theme/theme";
 const BIG_SCREEN_BREAKPOINT = BREAKPOINTS.topComponent.bigScreenView + "px";
 
 export const FormTitle = styled.span`
-	@import url("https://use.typekit.net/rvx4ppi.css");
-	font-family: ${pr => !pr.type && "Museo-Sans"};
+	${theme.museoSansFont}
+	font-family: ${pr => !pr.type && `'Museo-Sans', ${theme.fontFamily}`};
 	font-weight: ${pr => pr.type && pr.type === "drawer" && "medium"};
 
   color: ${theme.colors.almostBlack};

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -64,6 +64,7 @@ export default {
 		simplyGray: "1px solid #BEBEBE"
 	},
 	fontFamily : "-apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Ubuntu, Arial, sans-serif",
+	museoSansFont : "@import url('https://use.typekit.net/rvx4ppi.css');",
 	animations : {
 		backgroundMs : "250ms"
 	},


### PR DESCRIPTION
# What's included?
- Updated FormTitle's fontFamily to use the system font as a failsafe in case Museo-Sans fails.
- Added the Museo-Sans' import to theme.ts to export it and make it available to the consumer App (this will be tested until sv-mosaic's package gets a new patch version).